### PR TITLE
changes to ensure working ReactiveUI in WASM

### DIFF
--- a/src/System.Reactive.Wasm/Concurrency/ConcurrencyAbstractionLayerWasmImpl.cs
+++ b/src/System.Reactive.Wasm/Concurrency/ConcurrencyAbstractionLayerWasmImpl.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Threading;
 
@@ -41,7 +40,7 @@ namespace System.Reactive.Concurrency
         /// <inheritdoc />
         public IDisposable QueueUserWorkItem(Action<object> action, object state)
         {
-            System.Threading.ThreadPool.QueueUserWorkItem(_ => action(_), state);
+            ThreadPool.QueueUserWorkItem(_ => action(_), state);
             return Disposable.Empty;
         }
 
@@ -148,20 +147,22 @@ namespace System.Reactive.Concurrency
                 {
                     // Rooting of the timer happens through the this.Tick delegate's target object,
                     // which is the current instance and has a field to store the Timer instance.
-                    _timer = new System.Threading.Timer(Tick, state, dueTime, TimeSpan.FromMilliseconds(System.Threading.Timeout.Infinite));
+                    _timer = new System.Threading.Timer(Tick, state, dueTime, TimeSpan.FromMilliseconds(Timeout.Infinite));
                 }
             }
 
             public void Dispose()
             {
-                var timer = _timer;
-                if (timer != TimerStubs.Never)
+                System.Threading.Timer timer = _timer;
+                if (timer == TimerStubs.Never)
                 {
-                    _action = Stubs<object>.Ignore;
-                    _timer = TimerStubs.Never;
-
-                    timer.Dispose();
+                    return;
                 }
+
+                _action = Stubs<object>.Ignore;
+                _timer = TimerStubs.Never;
+
+                timer.Dispose();
             }
 
             private void Tick(object state)

--- a/src/System.Reactive.Wasm/Concurrency/ConcurrencyAbstractionLayerWasmImpl.cs
+++ b/src/System.Reactive.Wasm/Concurrency/ConcurrencyAbstractionLayerWasmImpl.cs
@@ -196,14 +196,16 @@ namespace System.Reactive.Concurrency
 
             public void Dispose()
             {
-                var timer = _timer;
-                if (timer != null)
+                System.Threading.Timer timer = _timer;
+                if (timer == null)
                 {
-                    _action = Stubs.Nop;
-                    _timer = null;
-
-                    timer.Dispose();
+                    return;
                 }
+
+                _action = Stubs.Nop;
+                _timer = null;
+
+                timer.Dispose();
             }
 
             private void Tick(object state) => _action();
@@ -218,7 +220,7 @@ namespace System.Reactive.Concurrency
             {
                 _action = action;
 
-                new System.Threading.Thread(Loop)
+                new Thread(Loop)
                 {
                     Name = "Rx-FastPeriodicTimer",
                     IsBackground = true

--- a/src/System.Reactive.Wasm/Internal/WasmPlatformEnlightenmentProvider.cs
+++ b/src/System.Reactive.Wasm/Internal/WasmPlatformEnlightenmentProvider.cs
@@ -18,15 +18,7 @@ namespace System.Reactive.PlatformServices
     public class WasmPlatformEnlightenmentProvider : CurrentPlatformEnlightenmentProvider
     {
         private static Lazy<bool> _isWasm = new Lazy<bool>(
-            () =>
-            {
-                if (ModeDetector.InUnitTestRunner())
-                {
-                    return true;
-                }
-
-                return MonoTest;
-            }, LazyThreadSafetyMode.PublicationOnly);
+            () => ModeDetector.InUnitTestRunner() || MonoTest, LazyThreadSafetyMode.PublicationOnly);
 
         /// <summary>Gets a value indicating whether the current executable is processing under WASM.</summary>
         public static bool IsWasm => _isWasm.Value;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix.  Reactive.Wasm had ceased to function correctly due to checks in the state of mono-wasm

**What is the current behavior?**

Errors thrown in mono-wasm.threading - unreachable code.

**What is the new behavior?**

Forces compliance to single-threaded mono-wasm model.

**What might this PR break?**

ReactiveUI.Blazor.  A second PR is being raised to address this.

